### PR TITLE
Add page-delimiter before the query string

### DIFF
--- a/wolfram.el
+++ b/wolfram.el
@@ -142,7 +142,7 @@ See https://products.wolframalpha.com/api/documentation/#width-mag"
   (wolfram--switch-to-wolfram-buffer)
   (goto-char (point-max))
   (let ((inhibit-read-only t))
-    (insert (format "# \"%s\" (searching)\n"
+    (insert (format "\n# \"%s\" (searching)\n"
                     (propertize query 'face 'wolfram-query)))))
 
 (defun wolfram--delete-in-progress-notification ()


### PR DESCRIPTION
This change allows the user to scroll through the results using 'C-x [' and 'C-x ]'.

Note that Github doesn't render "^L".